### PR TITLE
Support Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ These scripts install the required Python packages, launch a Navidrome container
 
 ### Prerequisites
 
-- Python 3.8 or higher
+ - Python 3.12 or higher
 - Node.js 14 or higher (for development)
 - Docker (optional, for containerized deployment)
 - API keys for OpenAI and ElevenLabs (required)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ pylast==5.2.0
 praw==7.7.1
 schedule==1.2.0
 m3u8==3.4.0
-numpy==1.24.3
-pandas==2.0.3
+numpy==1.26.4
+pandas==2.1.4

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- update numpy and pandas dependencies for Python 3.12
- document Python 3.12 requirement
- bump Dockerfile base image to python:3.12-slim

## Testing
- `pip3.12 install -r requirements.txt --break-system-packages`
- `PYTHONPATH=. pytest -q`

