### PR TITLE
Add support for OpenAI or Ollama LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
 # AI DJ Environment Variables
 
-# OpenAI API
+# Language Model Provider (openai or ollama)
+LLM_PROVIDER=openai
+
+# OpenAI API (used when LLM_PROVIDER=openai)
 OPENAI_API_KEY=your_openai_api_key
 OPENAI_MODEL=gpt-4
+
+# Ollama settings (used when LLM_PROVIDER=ollama)
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llama3
 
 # ElevenLabs API
 ELEVENLABS_API_KEY=your_elevenlabs_api_key

--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,16 @@
 # AI DJ Environment Variables
 # Copy this file to .env and fill in your API keys and configuration settings
 
-# OpenAI API Configuration
+# Language Model Provider (openai or ollama)
+LLM_PROVIDER=openai
+
+# OpenAI API Configuration (used when LLM_PROVIDER=openai)
 OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_MODEL=gpt-4
+
+# Ollama Configuration (used when LLM_PROVIDER=ollama)
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llama3
 
 # ElevenLabs API Configuration
 ELEVENLABS_API_KEY=your_elevenlabs_api_key_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,7 @@ All notable changes to this project will be documented in this file.
 - Improved install scripts to check for existing installations of Navidrome and Ollama before installing.
 - Added user friendly comments to installation scripts.
 - Added CHANGELOG file.
+- Added LLM provider support with new `LLM_PROVIDER` setting to switch between OpenAI and Ollama.
+- Introduced `LLMClient` abstraction and updated config validation to require either an OpenAI API key or an Ollama model.
+- Updated README and environment templates with new instructions.
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ An AI-powered DJ system that creates a personalized radio experience with automa
 
 Before you start, here is a quick overview of the services the project uses:
 
-- **OpenAI** – provides the language model that generates the DJ's responses.
+- **OpenAI** – provides the hosted language model that generates the DJ's responses.
 - **ElevenLabs** – turns those responses into natural sounding speech.
 - **Navidrome** – indexes your local music collection so tracks can be played.
-- **Ollama** – optional runtime for running local language models.
+- **Ollama** – runtime for running local language models.
 - **Docker** – runs Navidrome and can also run the app in containers.
 
 Configuration for these services is stored in the `.env` file.
@@ -76,7 +76,7 @@ cd ai-dj
 ./scripts/install.ps1
 ```
 
-These scripts install the required Python packages, launch a Navidrome container so your local music is available, and try to install the optional Ollama runtime. Once complete, copy `.env.example` to `.env`, fill in your API keys, then run `python start.py` to start the DJ.
+These scripts install the required Python packages, launch a Navidrome container so your local music is available, and attempt to install Ollama for running local models. Once complete, copy `.env.example` to `.env`, choose either OpenAI or Ollama as your language model provider, fill in the necessary keys or model name, then run `python start.py` to start the DJ.
 
 ---
 
@@ -87,7 +87,7 @@ These scripts install the required Python packages, launch a Navidrome container
  - Python 3.12 or higher
 - Node.js 14 or higher (for development)
 - Docker (optional, for containerized deployment)
-- API keys for OpenAI and ElevenLabs (required)
+- API key for OpenAI **or** a local Ollama model, and an ElevenLabs API key (required)
 - API keys for Last.fm and Spotify (optional, for enhanced music data)
 
 ### Setup Instructions
@@ -121,7 +121,7 @@ These scripts install the required Python packages, launch a Navidrome container
    cp .env.example .env
    ```
 
-5. Edit the `.env` file with your API keys and configuration settings. This file is ignored by Git and tells the app how to connect to each service.
+5. Edit the `.env` file with your API keys and configuration settings. Set `LLM_PROVIDER` to either `openai` or `ollama` and provide the corresponding credentials. This file is ignored by Git and tells the app how to connect to each service.
 
 6. Initialize the database (creates the SQLite files used for user settings):
    ```bash
@@ -148,7 +148,7 @@ These scripts install the required Python packages, launch a Navidrome container
    cp .env.example .env
    ```
 
-3. Edit the `.env` file with your API keys and configuration settings (same as the local setup).
+3. Edit the `.env` file with your API keys and configuration settings (same as the local setup). Be sure to set `LLM_PROVIDER` to `openai` or `ollama`.
 
 4. Build and start the Docker containers (this runs Navidrome and the AI DJ together):
    ```bash
@@ -159,12 +159,12 @@ These scripts install the required Python packages, launch a Navidrome container
 
 ### API Keys
 
-The following API keys are required or optional for full functionality:
-These services enable features like AI-generated speech and music recommendations.
+The following keys or settings are required or optional for full functionality. At least one language model provider must be configured.
 
-- **OpenAI API Key** (Required): For generating DJ responses
+- **OpenAI API Key** (Required if using OpenAI): For generating DJ responses
   - Sign up at [OpenAI](https://platform.openai.com/signup)
   - Create an API key at [OpenAI API Keys](https://platform.openai.com/api-keys)
+- **Ollama Model Name** (Required if using Ollama): Name of the local model to load
 
 - **ElevenLabs API Key** (Required): For text-to-speech conversion
   - Sign up at [ElevenLabs](https://elevenlabs.io/)

--- a/server/app.py
+++ b/server/app.py
@@ -16,7 +16,7 @@ from utils.error_handler import (
 )
 from utils.config import Config
 from utils.navidrome import NavidromeClient
-from integrations.openai_client import OpenAIClient
+from integrations.llm_client import LLMClient
 from integrations.elevenlabs_client import ElevenLabsClient
 from integrations.lastfm_client import LastFMClient
 from integrations.spotify_client import SpotifyClient
@@ -74,10 +74,18 @@ def internal_error(error):
 
 # Initialize clients
 try:
-    # Initialize OpenAI client
-    openai_api_key = os.getenv('OPENAI_API_KEY')
-    validate_api_key(openai_api_key, 'OpenAI')
-    openai_client = OpenAIClient(api_key=openai_api_key)
+    # Determine language model provider
+    llm_provider = os.getenv('LLM_PROVIDER', 'openai').lower()
+
+    if llm_provider == 'ollama':
+        ollama_model = os.getenv('OLLAMA_MODEL')
+        if not ollama_model:
+            raise MusicServiceError('OLLAMA_MODEL not specified', 'Ollama')
+        openai_client = LLMClient(provider='ollama', model=ollama_model)
+    else:
+        openai_api_key = os.getenv('OPENAI_API_KEY')
+        validate_api_key(openai_api_key, 'OpenAI')
+        openai_client = LLMClient(provider='openai', api_key=openai_api_key)
     
     # Initialize ElevenLabs client
     elevenlabs_api_key = os.getenv('ELEVENLABS_API_KEY')

--- a/server/integrations/llm_client.py
+++ b/server/integrations/llm_client.py
@@ -1,0 +1,161 @@
+import os
+import json
+import logging
+import requests
+from datetime import datetime
+from openai import OpenAI
+
+logger = logging.getLogger(__name__)
+
+class LLMClient:
+    """Unified client for OpenAI or Ollama language models."""
+
+    def __init__(self, provider='openai', api_key=None, base_url=None, model=None):
+        self.provider = provider
+
+        if provider == 'openai':
+            api_key = api_key or os.getenv('OPENAI_API_KEY')
+            self.client = OpenAI(api_key=api_key)
+            self.model = model or os.getenv('OPENAI_MODEL', 'gpt-4')
+        elif provider == 'ollama':
+            self.base_url = base_url or os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434')
+            self.model = model or os.getenv('OLLAMA_MODEL', 'llama3')
+        else:
+            raise ValueError("Unsupported provider: %s" % provider)
+
+        # Load prompt templates
+        self.templates = {}
+        self._load_templates()
+
+    def _load_templates(self):
+        """Load prompt templates from the prompts directory."""
+        prompts_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'prompts')
+
+        if not os.path.exists(prompts_dir):
+            os.makedirs(prompts_dir)
+            self._create_default_templates(prompts_dir)
+
+        try:
+            for filename in os.listdir(prompts_dir):
+                if filename.endswith('.json'):
+                    template_name = filename[:-5]
+                    with open(os.path.join(prompts_dir, filename), 'r') as f:
+                        self.templates[template_name] = json.load(f)
+            logger.info("Loaded %d prompt templates", len(self.templates))
+        except Exception as e:
+            logger.error("Error loading prompt templates: %s", str(e))
+
+    def _create_default_templates(self, prompts_dir):
+        """Create default prompt templates."""
+        default_templates = {
+            "playlist_generator": {
+                "system": "You are an expert music curator and DJ assistant. Your task is to create a cohesive and engaging playlist based on the user's preferences, recent listening history, and specified mood or theme.",
+                "user": "Create a playlist with {count} songs that matches the mood: '{mood}' and theme: '{theme}'. Consider these recently played songs: {recent_plays}. For each song, include the artist name, song title, and a brief reason why it fits the playlist."
+            },
+            "song_info": {
+                "system": "You are a music expert with deep knowledge of artists, genres, music history, and interesting trivia. Provide engaging and accurate information about songs.",
+                "user": "Provide interesting information about the song '{title}' by {artist}. Include genre information, historical context, fun facts, and what makes this song special. Keep it concise but engaging, like a DJ might introduce the song."
+            },
+            "dj_intro": {
+                "system": "You are a charismatic DJ introducing the next song or playlist to your audience. Your intros are engaging, informative, and build excitement for the music that's about to play.",
+                "user": "Create a DJ introduction for the song '{title}' by {artist} from the playlist '{playlist_name}'. Make it sound natural, engaging, and brief (30-60 words). Include a reference to the mood, genre, or theme of the song."
+            },
+            "trend_analyzer": {
+                "system": "You are a music trend analyst who can identify patterns and connections between different music trends and a user's personal music collection.",
+                "user": "Analyze these current music trends: {trends}. Compare them with the user's recent listening: {recent_plays}. Identify connections, recommend songs from trends that match the user's taste, and suggest songs from their collection that align with current trends."
+            }
+        }
+        for name, template in default_templates.items():
+            with open(os.path.join(prompts_dir, f"{name}.json"), 'w') as f:
+                json.dump(template, f, indent=2)
+        logger.info("Created %d default prompt templates", len(default_templates))
+
+    def _format_prompt(self, template_name, **kwargs):
+        """Format a prompt template with provided variables."""
+        if template_name not in self.templates:
+            logger.warning("Template %s not found, using default", template_name)
+            return [
+                {"role": "system", "content": "You are an AI assistant for a music application."},
+                {"role": "user", "content": str(kwargs)}
+            ]
+
+        template = self.templates[template_name]
+        system_content = template["system"]
+        user_content = template["user"].format(**kwargs)
+        return [
+            {"role": "system", "content": system_content},
+            {"role": "user", "content": user_content}
+        ]
+
+    def chat_completion(self, messages, temperature=0.7, max_tokens=500):
+        """Send a chat completion request to the configured provider."""
+        try:
+            if self.provider == 'openai':
+                response = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens
+                )
+                return response.choices[0].message.content
+            else:
+                payload = {
+                    "model": self.model,
+                    "messages": messages,
+                    "stream": False,
+                    "options": {"temperature": temperature}
+                }
+                r = requests.post(f"{self.base_url}/api/chat", json=payload, timeout=60)
+                r.raise_for_status()
+                data = r.json()
+                return data.get('message', {}).get('content', '')
+        except Exception as e:
+            logger.error("Error during chat completion: %s", str(e))
+            raise
+
+    def generate_song_info(self, artist, title):
+        messages = self._format_prompt("song_info", artist=artist, title=title)
+        content = self.chat_completion(messages, max_tokens=500)
+        return {
+            'info': content,
+            'generated_at': datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        }
+
+    def generate_dj_intro(self, song_info, playlist_name=""):
+        artist = song_info.get('artist', 'Unknown Artist')
+        title = song_info.get('title', 'Unknown Title')
+        messages = self._format_prompt(
+            "dj_intro",
+            artist=artist,
+            title=title,
+            playlist_name=playlist_name
+        )
+        return self.chat_completion(messages, temperature=0.8, max_tokens=200)
+
+    def analyze_trends(self, trends, recent_plays):
+        formatted_trends = []
+        for source, items in trends.items():
+            formatted_trends.append(f"{source.upper()} TRENDS:")
+            for item in items:
+                if isinstance(item, dict):
+                    if 'artist' in item and 'title' in item:
+                        formatted_trends.append(f"- {item['artist']} - {item['title']}")
+                    elif 'name' in item:
+                        formatted_trends.append(f"- {item['name']}")
+                else:
+                    formatted_trends.append(f"- {item}")
+        trends_str = "\n".join(formatted_trends)
+
+        formatted_plays = [f"{s.get('artist', 'Unknown Artist')} - {s.get('title', 'Unknown Title')}" for s in recent_plays]
+        recent_plays_str = ", ".join(formatted_plays)
+
+        messages = self._format_prompt(
+            "trend_analyzer",
+            trends=trends_str,
+            recent_plays=recent_plays_str
+        )
+        content = self.chat_completion(messages, max_tokens=800)
+        return {
+            'analysis': content,
+            'generated_at': datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        }

--- a/server/routes/dj_interaction.py
+++ b/server/routes/dj_interaction.py
@@ -96,17 +96,11 @@ def generate_music_trivia(dj_profile=None, tone=None):
         if tone and tone != 'default':
             system_prompt = f"{system_prompt}\nRespond in a {tone} style."
         
-        # Generate trivia using OpenAI
-        response = openai_client.client.chat.completions.create(
-            model="gpt-4",
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": trivia_prompt["user"]}
-            ],
-            max_tokens=250
-        )
-        
-        trivia_text = response.choices[0].message.content.strip()
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": trivia_prompt["user"]}
+        ]
+        trivia_text = openai_client.chat_completion(messages, max_tokens=250).strip()
         
         return {
             "response": trivia_text,
@@ -154,17 +148,11 @@ def generate_song_info(now_playing, dj_profile=None, tone=None):
         if tone and tone != 'default':
             system_prompt = f"{system_prompt}\nRespond in a {tone} style."
         
-        # Generate song info using OpenAI
-        response = openai_client.client.chat.completions.create(
-            model="gpt-4",
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt}
-            ],
-            max_tokens=300
-        )
-        
-        song_info_text = response.choices[0].message.content.strip()
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt}
+        ]
+        song_info_text = openai_client.chat_completion(messages, max_tokens=300).strip()
         
         return {
             "response": song_info_text,
@@ -205,13 +193,7 @@ def handle_general_conversation(user_request, context, dj_profile=None, tone=Non
             {"role": "user", "content": f"Current song: {now_playing.get('title', 'Unknown')} by {now_playing.get('artist', 'Unknown')}\n\nUser request: {user_request}"}
         ]
         
-        response = openai_client.client.chat.completions.create(
-            model="gpt-4",
-            messages=messages,
-            max_tokens=250
-        )
-        
-        chat_response = response.choices[0].message.content.strip()
+        chat_response = openai_client.chat_completion(messages, max_tokens=250).strip()
         
         return {
             "response": chat_response,
@@ -441,17 +423,11 @@ def check_music_relevance(request_text):
     # Format the prompt with the request
     user_prompt = moderation_prompt["user"].format(request=request_text)
     
-    # Check content using OpenAI
-    response = openai_client.client.chat.completions.create(
-        model="gpt-4",
-        messages=[
-            {"role": "system", "content": moderation_prompt["system"]},
-            {"role": "user", "content": user_prompt}
-        ],
-        max_tokens=150
-    )
-    
-    result = response.choices[0].message.content.strip()
+    messages = [
+        {"role": "system", "content": moderation_prompt["system"]},
+        {"role": "user", "content": user_prompt}
+    ]
+    result = openai_client.chat_completion(messages, max_tokens=150).strip()
     
     if result.startswith("MUSIC_RELATED"):
         return True, "Music-related content"

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -14,9 +14,12 @@ class Config:
         self.navidrome_username = os.getenv('NAVIDROME_USERNAME', '')
         self.navidrome_password = os.getenv('NAVIDROME_PASSWORD', '')
         
-        # OpenAI configuration
+        # Language model configuration
+        self.llm_provider = os.getenv('LLM_PROVIDER', 'openai').lower()
         self.openai_api_key = os.getenv('OPENAI_API_KEY', '')
         self.openai_model = os.getenv('OPENAI_MODEL', 'gpt-4')
+        self.ollama_base_url = os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434')
+        self.ollama_model = os.getenv('OLLAMA_MODEL', '')
         
         # ElevenLabs configuration
         self.elevenlabs_api_key = os.getenv('ELEVENLABS_API_KEY', '')
@@ -43,9 +46,15 @@ class Config:
         """Validate that all required configuration is present."""
         missing_vars = []
         
-        # Check required variables
-        if not self.openai_api_key:
+        # Ensure at least one language model is configured
+        if not self.openai_api_key and not self.ollama_model:
+            missing_vars.append('OPENAI_API_KEY or OLLAMA_MODEL')
+
+        if self.llm_provider == 'openai' and not self.openai_api_key:
             missing_vars.append('OPENAI_API_KEY')
+        if self.llm_provider == 'ollama' and not self.ollama_model:
+            missing_vars.append('OLLAMA_MODEL')
+
         if not self.elevenlabs_api_key:
             missing_vars.append('ELEVENLABS_API_KEY')
         if not self.navidrome_username or not self.navidrome_password:


### PR DESCRIPTION
## Summary
- support both OpenAI and Ollama for language model interactions
- introduce `LLMClient` abstraction
- make provider configurable through `LLM_PROVIDER`
- update config validation and environment templates
- document new setup steps and requirements

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517f545bac83298475f16466a2a541