### PR TITLE
Update README with clearer language model info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ All notable changes to this project will be documented in this file.
 - Added LLM provider support with new `LLM_PROVIDER` setting to switch between OpenAI and Ollama.
 - Introduced `LLMClient` abstraction and updated config validation to require either an OpenAI API key or an Ollama model.
 - Updated README and environment templates with new instructions.
+- Clarified in README that OpenAI or Ollama generate the DJ's responses.
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ An AI-powered DJ system that creates a personalized radio experience with automa
 
 Before you start, here is a quick overview of the services the project uses:
 
-- **OpenAI** – provides the hosted language model that generates the DJ's responses.
+- **OpenAI** – hosted language model service that generates the DJ's responses.
 - **ElevenLabs** – turns those responses into natural sounding speech.
 - **Navidrome** – indexes your local music collection so tracks can be played.
-- **Ollama** – runtime for running local language models.
+- **Ollama** – local runtime for generating DJ responses with local models.
 - **Docker** – runs Navidrome and can also run the app in containers.
 
 Configuration for these services is stored in the `.env` file.


### PR DESCRIPTION
## Summary
- clarify that DJ responses are generated using OpenAI or Ollama
- note the change in the changelog
- Both Ollama and OpenAI can be used to generate the DJ response 

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$(pwd) pytest -q`
