### PR TITLE
Handle existing Navidrome/Ollama installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Improved install scripts to check for existing installations of Navidrome and Ollama before installing.
+- Scripts now prompt for confirmation when Navidrome or Ollama are already present, preventing port conflicts.
 - Added user friendly comments to installation scripts.
 - Added CHANGELOG file.
 - Added LLM provider support with new `LLM_PROVIDER` setting to switch between OpenAI and Ollama.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,24 +15,51 @@ python -m pip install -r requirements.txt
 
 # Pull and run Navidrome via Docker if available and not already running
 if (Get-Command docker -ErrorAction SilentlyContinue) {
+    $skipNavidrome = $false
     Write-Host "Setting up Navidrome music server..."
     $exists = docker ps -a --format '{{.Names}}' | Select-String -Pattern '^navidrome$'
-    if (-not $exists) {
+    $portUsed = Get-NetTCPConnection -LocalPort 4533 -ErrorAction SilentlyContinue
+    if ($exists) {
+        $answer = Read-Host "Navidrome container already exists. Reinstall? (y/N)"
+        if ($answer -match '^[Yy]$') {
+            docker stop navidrome | Out-Null 2>&1
+            docker rm navidrome | Out-Null 2>&1
+        } else {
+            Write-Host "Skipping Navidrome installation."
+            $skipNavidrome = $true
+        }
+    } elseif ($portUsed) {
+        $answer = Read-Host "Port 4533 is in use. Continue with installation? (y/N)"
+        if ($answer -notmatch '^[Yy]$') {
+            Write-Host "Skipping Navidrome installation due to port conflict."
+            $skipNavidrome = $true
+        }
+    }
+
+    if (-not $skipNavidrome) {
         docker pull deluan/navidrome:latest
         New-Item -ItemType Directory -Force -Path "data/navidrome" | Out-Null
         docker run -d --name navidrome -p 4533:4533 -v "$PWD/data/navidrome:/data" -v "$env:USERPROFILE\Music:/music:ro" deluan/navidrome:latest | Out-Null
-    }
-    else {
-        Write-Host "Navidrome container already exists. Skipping installation."
     }
 } else {
     Write-Host "Docker not found. Install Docker Desktop to enable the local music server." -ForegroundColor Yellow
 }
 
-# Ollama installation hint
-if (-not (Get-Command ollama -ErrorAction SilentlyContinue)) {
-    Write-Host "Please install Ollama manually from https://ollama.ai" -ForegroundColor Yellow
+# Ollama installation
+function Install-Ollama {
+    if (Get-Command ollama -ErrorAction SilentlyContinue) {
+        $answer = Read-Host "Ollama already installed. Reinstall/upgrade? (y/N)"
+        if ($answer -notmatch '^[Yy]$') {
+            Write-Host "Skipping Ollama installation."
+            return
+        }
+    }
+    Write-Host "Installing Ollama..."
+    Write-Host "Please follow the prompts from the installer." -ForegroundColor Yellow
+    Invoke-Expression (Invoke-WebRequest -UseBasicParsing https://ollama.ai/install.ps1).Content
 }
+
+Install-Ollama
 
 Write-Host "Setup complete! Edit the .env file with your API keys and run 'python start.py' to launch AI DJ." -ForegroundColor Green
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,13 @@
 # services (Navidrome and Ollama) only if they are not already present.
 set -euo pipefail
 
+# Function to prompt user with a yes/no question
+confirm() {
+    # $1: message
+    read -r -p "$1 [y/N] " response
+    [[ "$response" =~ ^[Yy]$ ]
+}
+
 echo "=== AI DJ Setup ==="
 
 # Determine platform for optional Ollama installer
@@ -19,18 +26,43 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Check if a TCP port is already in use (requires lsof or netstat)
+port_in_use() {
+    local port="$1"
+    if command_exists lsof; then
+        lsof -i ":${port}" >/dev/null 2>&1
+    elif command_exists netstat; then
+        netstat -tuln | grep -q ":${port} "
+    else
+        return 1
+    fi
+}
+
 # Helper to install Navidrome only when the container is not already running
 install_navidrome() {
     echo "Setting up Navidrome music server..."
-    if ! docker ps -a --format '{{.Names}}' | grep -q '^navidrome$'; then
-        docker pull deluan/navidrome:latest
-        mkdir -p data/navidrome
-        docker run -d --name navidrome -p 4533:4533 \
-            -v "$PWD/data/navidrome:/data" \
-            -v "$HOME/Music:/music:ro" deluan/navidrome:latest
-    else
-        echo "Navidrome container already exists. Skipping installation."
+    if docker ps -a --format '{{.Names}}' | grep -q '^navidrome$'; then
+        echo "Navidrome container already exists."
+        if confirm "Reinstall Navidrome container?"; then
+            docker stop navidrome >/dev/null 2>&1 || true
+            docker rm navidrome >/dev/null 2>&1 || true
+        else
+            echo "Skipping Navidrome installation."
+            return
+        fi
+    elif port_in_use 4533; then
+        echo "Port 4533 is already in use."
+        if ! confirm "Continue with Navidrome installation anyway?"; then
+            echo "Skipping Navidrome installation due to port conflict."
+            return
+        fi
     fi
+
+    docker pull deluan/navidrome:latest
+    mkdir -p data/navidrome
+    docker run -d --name navidrome -p 4533:4533 \
+        -v "$PWD/data/navidrome:/data" \
+        -v "$HOME/Music:/music:ro" deluan/navidrome:latest
 }
 
 # Ensure Python 3 is available
@@ -49,8 +81,15 @@ else
     echo "Docker not found. Please install Docker to enable the local music server." >&2
 fi
 
-# Install Ollama for local LLMs if missing
-if ! command_exists ollama; then
+# Install Ollama for local LLMs
+install_ollama() {
+    if command_exists ollama; then
+        if ! confirm "Ollama is already installed. Reinstall/upgrade?"; then
+            echo "Skipping Ollama installation."
+            return
+        fi
+    fi
+
     echo "Installing Ollama..."
     case "$PLATFORM" in
         mac|linux)
@@ -60,7 +99,9 @@ if ! command_exists ollama; then
             echo "Please install Ollama manually from https://ollama.ai" >&2
             ;;
     esac
-fi
+}
+
+install_ollama
 
 echo "Setup complete! Edit the .env file with your API keys and run 'python start.py' to launch AI DJ."
 


### PR DESCRIPTION
## Summary
- prompt for confirmation when navidrome or ollama are already installed
- improve install scripts with port checks and reinstall options
- update changelog

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`
