### PR TITLE
Add init_db script and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,6 @@ All notable changes to this project will be documented in this file.
 - Updated `scripts/install.sh` to install requirements without the `--user` flag.
 - Documented virtual environment setup in the Quick Start guide.
 - Changed prerequisite to recommend Python 3.10 or 3.11.
+- Added `server/init_db.py` script for initializing or testing the database.
+- Updated README and troubleshooting guide to run `python server/init_db.py` after configuring `.env`.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,12 @@ source venv/bin/activate
 ./scripts/install.ps1
 ```
 
-These scripts install the required Python packages, launch a Navidrome container so your local music is available, and attempt to install Ollama for running local models. Once complete, copy `.env.example` to `.env`, choose either OpenAI or Ollama as your language model provider, fill in the necessary keys or model name, then run `python start.py` to start the DJ.
+These scripts install the required Python packages, launch a Navidrome container so your local music is available, and attempt to install Ollama for running local models. Once complete, copy `.env.example` to `.env`, choose either OpenAI or Ollama as your language model provider, fill in the necessary keys or model name, then **initialize the database** and start the DJ:
+
+```bash
+python server/init_db.py
+python start.py
+```
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,10 @@
 # AI DJ Troubleshooting Guide
 
+## Initial Setup
+
+1. Copy `.env.example` to `.env` and fill in your API keys.
+2. Run `python server/init_db.py` to create the local database.
+
 ## Common Errors and Solutions
 
 ### API Key Errors (401)

--- a/server/init_db.py
+++ b/server/init_db.py
@@ -1,0 +1,37 @@
+import logging
+import argparse
+from routes.settings import init_db, get_db_connection
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def test_connection():
+    """Test database connectivity."""
+    try:
+        conn = get_db_connection()
+        conn.execute("SELECT 1")
+        conn.close()
+        logger.info("Database connection successful.")
+        return True
+    except Exception as e:
+        logger.exception("Database connection failed: %s", e)
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Initialize or test the AI DJ database")
+    parser.add_argument("--test", action="store_true", help="Only test the database connection")
+    args = parser.parse_args()
+
+    if args.test:
+        test_connection()
+        return
+
+    try:
+        init_db()
+        logger.info("Database initialized successfully.")
+    except Exception as e:
+        logger.exception("Database initialization failed: %s", e)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `server/init_db.py` for database initialization or testing
- mention `python server/init_db.py` in Quick Start steps
- add initial setup section in troubleshooting guide
- note new script in changelog

## Testing
- `pip install pytest`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cae4e6b208329829c650b9f3dcf72